### PR TITLE
Add Core200S to Supported Fans in vesync Documentation

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -50,6 +50,7 @@ This integration supports devices controllable by the VeSync App.  The following
 ### Fans
 
 - LEVOIT Smart Wifi Air Purifier (LV-PUR131S)
+- LEVOIT Core 200S Smart True HEPA Air Purifier (Core200S)
 
 ## Prerequisite
 
@@ -80,17 +81,19 @@ VeSync outlets will expose the following details for only the smart outlets. Ene
 
 ## Fan Exposed Attributes
 
-VeSync air purifiers will expose the following details.
+VeSync air purifiers will expose the following details depending on the features supported by the model:
 
-| Attribute               | Description                                                             | Example         |
-| ----------------------- | ----------------------------------------------------------------------- | --------------- |
-| `mode`                  | The current mode the device is in.                                      | manual          |
-| `speed`                 | The current speed setting of the device.                                | high            |
-| `speed_list`            | The available list of speeds supported by the device.                   | high            |
-| `active_time`           | The number of seconds since the device has been in a non-off mode.      | 1598            |
-| `filter_life`           | Remaining percentage of the filter.                                     | 142             |
-| `air_quality`           | The current air quality reading.                                        | excellent       |
-| `screen_status`         | The current status of the screen.                                       | on              |
+| Attribute               | Description                                                                       | Example         |
+| ----------------------- | --------------------------------------------------------------------------------- | --------------- |
+| `mode`                  | The current mode the device is in. (LV-PUR131S, Core200S)                         | manual          |
+| `speed`                 | The current speed setting of the device. (LV-PUR131S, Core200S)                   | high            |
+| `speed_list`            | The available list of speeds supported by the device. (LV-PUR131S)                | high            |
+| `active_time`           | The number of seconds since the device has been in a non-off mode. (LV-PUR131S)   | 1598            |
+| `filter_life`           | Remaining percentage of the filter. (LV-PUR131S, Core200S)                        | 142             |
+| `air_quality`           | The current air quality reading. (LV-PUR131S)                                     | excellent       |
+| `screen_status`         | The current status of the screen. (LV-PUR131S)                                    | on              |
+| `night_light`           | The current status of the night light (Core200S)                                  | off             |
+| `child_lock`            | The current status of the child lock (Core200S)                                   | off             |
 
 ## Extracting Attribute data
 


### PR DESCRIPTION
Adding the Core200S to the supported devices as well as showing which attributes are supported by each fan type.

## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updates documentation for vesync to include supporting the Core200S air purifier. Also documents the fan attributes by device type.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [https://github.com/home-assistant/core/pull/50216](https://github.com/home-assistant/core/pull/50216)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
